### PR TITLE
add uuid dependency to solve MODULE_NOT_FOUND issue

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,5 @@ node_modules
 CONTRIBUTING.md
 Dockerfile*
 jest.config.js
+*.iml
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+*.iml
+.idea/

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "contentful-management": "^7.44.2",
+    "uuid": "^8.3.2",
     "yargs": "^17.2.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3297,6 +3297,11 @@ util-deprecate@^1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 v8-to-istanbul@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-8.1.0.tgz#0aeb763894f1a0a1676adf8a8b7612a38902446c"


### PR DESCRIPTION
Hi, I add this pull request to solve an issue came from using the latest docker version of the cli:

❯ docker run --rm --name contentful-migration-runner -e CONTENT_MANAGEMENT_TOKEN=$CONTENT_MANAGEMENT_TOKEN -e SPACE_ID=$SPACE_ID -e ENVIRONMENT_ID=$ENVIRONMENT_ID -v $(pwd)/migrations:/app/migrations marcomontalbano/contentful-migration:v1.1.0
yarn run v1.22.15
$ /app/node_modules/.bin/ts-node docker.ts
- Remove contentful-migration
- Install contentful-migration@latest
- Run migration
Error: Cannot find module 'uuid'
Require stack:
- /app/node_modules/contentful-migration/built/bin/lib/config.js
- /app/node_modules/contentful-migration/built/bin/cli.js
- /app/node_modules/contentful-migration/built/index.js
- /app/src/migration.ts
- /app/runner.ts
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
    at Function.Module._resolveFilename.sharedData.moduleResolveFilenameHook.installedValue [as _resolveFilename] (/app/node_modules/@cspotcode/source-map-support/source-map-support.js:679:30)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:93:18)
    at Object.<anonymous> (/app/node_modules/contentful-migration/src/bin/lib/config.ts:3:1)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:93:18)
    at Object.<anonymous> (/app/node_modules/contentful-migration/src/bin/cli.ts:17:1)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/app/node_modules/contentful-migration/built/bin/lib/config.js',
    '/app/node_modules/contentful-migration/built/bin/cli.js',
    '/app/node_modules/contentful-migration/built/index.js',
    '/app/src/migration.ts',
    '/app/runner.ts'
  ]
}
Error: Command failed: ts-node runner.ts run /app/migrations
    at checkExecSyncError (child_process.js:790:11)
    at execSync (child_process.js:863:15)
    at runMigration (/app/docker.ts:33:11)
    at /app/docker.ts:48:3
    at step (/app/docker.ts:33:23)
    at Object.next (/app/docker.ts:14:53)
    at /app/docker.ts:8:71
    at new Promise (<anonymous>)
    at __awaiter (/app/docker.ts:4:12)
    at /app/docker.ts:78:12 {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 56,
  stdout: null,
  stderr: null
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
